### PR TITLE
Always return non-const object from AutoPtr/SharedPtr

### DIFF
--- a/Foundation/include/Poco/AutoPtr.h
+++ b/Foundation/include/Poco/AutoPtr.h
@@ -182,7 +182,7 @@ public:
 		return AutoPtr<Other>(pOther, true);
 	}
 
-	C* operator -> ()
+	C* operator -> () const
 	{
 		if (_ptr)
 			return _ptr;
@@ -190,15 +190,7 @@ public:
 			throw NullPointerException();
 	}
 
-	const C* operator -> () const
-	{
-		if (_ptr)
-			return _ptr;
-		else
-			throw NullPointerException();
-	}
-
-	C& operator * ()
+	C& operator * () const
 	{
 		if (_ptr)
 			return *_ptr;
@@ -206,30 +198,12 @@ public:
 			throw NullPointerException();
 	}
 
-	const C& operator * () const
-	{
-		if (_ptr)
-			return *_ptr;
-		else
-			throw NullPointerException();
-	}
-
-	C* get()
+	C* get() const
 	{
 		return _ptr;
 	}
 
-	const C* get() const
-	{
-		return _ptr;
-	}
-
-	operator C* ()
-	{
-		return _ptr;
-	}
-	
-	operator const C* () const
+	operator C* () const
 	{
 		return _ptr;
 	}

--- a/Foundation/include/Poco/SharedPtr.h
+++ b/Foundation/include/Poco/SharedPtr.h
@@ -233,42 +233,22 @@ public:
 		return SharedPtr<Other, RC, RP>(_pCounter, pOther);
 	}
 
-	C* operator -> ()
+	C* operator -> () const
 	{
 		return deref();
 	}
 
-	const C* operator -> () const
-	{
-		return deref();
-	}
-
-	C& operator * ()
+	C& operator * () const
 	{
 		return *deref();
 	}
 
-	const C& operator * () const
-	{
-		return *deref();
-	}
-
-	C* get()
+	C* get() const
 	{
 		return _ptr;
 	}
 
-	const C* get() const
-	{
-		return _ptr;
-	}
-
-	operator C* ()
-	{
-		return _ptr;
-	}
-	
-	operator const C* () const
+	operator C* () const
 	{
 		return _ptr;
 	}


### PR DESCRIPTION
Returning pointer or reference to const object from const AutoPtr/SharedPtr
methods is incorrect: constant smart ptr should mean constant raw pointer and
reference counter (which are its members), but not constant pointee (which is
not the member). This change also brings Poco smart ptrs in line with std::
smart ptr classes which don't make pointees transitively constant either.

Another use-case permitted with this change: it's now possible to declare
AutoPtr/SharedPtr const on stack or as member variable, to prevent the pointer
change, and still be able to call non-const methods on pointee.
